### PR TITLE
add error message if initial column isn't selected

### DIFF
--- a/app/components/select-column.js
+++ b/app/components/select-column.js
@@ -6,12 +6,8 @@ export default Ember.Component.extend({
     return this.model.webServiceResponse.source_data.results;
   }),
   actions: {
-    chooseField: function(heading, column){
-      Ember.set(this.model.submission.get('oaFields')[heading], "fields", []);
-      this.model.submission.get('oaFields')[heading].fields.addObject(column);
-      for (var i = 0; i < 2; i++){
-        Ember.set(this.model.submission.get('exampleRows')[i], heading, [this.model.webServiceResponse.source_data.results[i][column]]);
-      }
+    sendChooseField: function(heading, column){
+      this.sendAction('sendChooseField', heading, column);
     },
     removeField: function(heading){
       var column = this.model.submission.get('oaFields')[heading].fields[0];

--- a/app/controllers/data-format.js
+++ b/app/controllers/data-format.js
@@ -43,20 +43,42 @@ export default Ember.Controller.extend(sharedActions, {
     };
     return nextFields[this.get('currentField')];
   }),
+  showErrorState: false,
+  errorMessages: [],
+  resetErrorState: function () {
+    Ember.set(this, 'showErrorState', false);
+    Ember.set(this, 'errorMessages', []);
+  },
   actions: {
     goToField: function(field){
       this.set('currentField', field);
     },
     prevField: function() {
+      this.resetErrorState();
       this.set('currentField', this.get('prevField'));
     },
     nextField: function(){
+      this.resetErrorState();
       this.set('currentField', this.get('nextField'));
     },
+    chooseField: function(heading, column){
+      Ember.set(this.model.submission.get('oaFields')[heading], "fields", []);
+      this.model.submission.get('oaFields')[heading].fields.addObject(column);
+      for (var i = 0; i < 2; i++){
+        Ember.set(this.model.submission.get('exampleRows')[i], heading, [this.model.webServiceResponse.source_data.results[i][column]]);
+      }
+      this.resetErrorState();
+    },
     addFunction: function(field, action){
-      Ember.set(this.model.submission.get('oaFields')[field], "function", action);
-      if (action === "join"){
-        this.set('showAdditionalJoinDropdown', true);
+      if (this.model.submission.get('oaFields')[field].fields.length > 0){
+        this.resetErrorState();
+        Ember.set(this.model.submission.get('oaFields')[field], "function", action);
+        if (action === "join"){
+          this.set('showAdditionalJoinDropdown', true);
+        }
+      } else {
+        this.set('showErrorState', true);
+        this.set('errorMessages', ['Select a column from the drop down to proceed']);
       }
     },
     removeFunction: function(field){

--- a/app/templates/components/select-column.hbs
+++ b/app/templates/components/select-column.hbs
@@ -1,7 +1,7 @@
 <div class="field">
   <div class="fields">
     <div class="sixteen wide field">
-      {{#ui-dropdown class="selection fluid data-format" selected=properties.fields.firstObject onChange=(action "chooseField" field) as |execute mapper|}}
+      {{#ui-dropdown class="selection fluid data-format" selected=properties.fields.firstObject onChange=(action "sendChooseField" field) as |execute mapper|}}
         <div class="default text">
           Source column headings
         </div>

--- a/app/templates/data-format.hbs
+++ b/app/templates/data-format.hbs
@@ -99,8 +99,17 @@
               <span class="required"> * </span>
             {{/if}}
           </label>
+          {{#if showErrorState}}
+            <div>
+              <ul class="list">
+                {{#each errorMessages as |errorMessage|}}
+                  <li>{{errorMessage}}</li>
+                {{/each}}
+              </ul>
+            </div>
+          {{/if}}
           {{#unless (eq properties.function "join")}}
-            {{select-column field=field properties=properties columnHeadings=columnHeadings model=model}}
+            {{select-column field=field properties=properties columnHeadings=columnHeadings model=model sendChooseField="chooseField"}}
           {{/unless}}
           {{#if (eq properties.function "join")}}
             {{join-column field=field properties=properties showAdditionalJoinDropdown=showAdditionalJoinDropdown model=model}}


### PR DESCRIPTION
This adds an error message when the user tries to click `Join columns` or `Split column` without selecting a column from the initial dropdown.

In the `select-column` component, I switched the `chooseField` action to sending that action to the data-format controller, so that the error state could be cleared when a column is selected.

Closes #106 