### PR TITLE
clear share-alike status when a new license is chosen or a new url is  provided

### DIFF
--- a/app/controllers/more-info.js
+++ b/app/controllers/more-info.js
@@ -156,6 +156,7 @@ export default Ember.Controller.extend(sharedActions, {
       this.model.set('update_frequency', frequency);
     },
     setRadioButton: function(type) {
+      this.model.set('share_alike', null);
       this.set('licenseType', type);
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ember-ajax": "^3.0.0",
     "ember-changeset": "^1.3.0",
     "ember-changeset-validations": "^1.2.8",
-    "ember-cli": "~2.14.2",
+    "ember-cli": "^2.18.2",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-babel": "^6.3.0",
     "ember-cli-dependency-checker": "^1.3.0",


### PR DESCRIPTION
May need to have others test this interaction to make sure it isn't awkward for the user.

Closes #180 