### PR TITLE
pass in column as heading to find sample value

### DIFF
--- a/app/templates/components/join-column.hbs
+++ b/app/templates/components/join-column.hbs
@@ -12,7 +12,7 @@
       <div class="fifteen wide field">
         {{#ui-dropdown class="selection fluid data-format" selected=column onChange=(action "editField" field index) as |execute mapper|}}
           <div>
-            {{column}} (example value: {{sample-data user_data=user_data}}
+            {{column}} (example value: {{sample-data user_data=user_data heading=column}}
           </div>
           <i class="dropdown icon"></i>
           <div class="menu">

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ember-ajax": "^3.0.0",
     "ember-changeset": "^1.3.0",
     "ember-changeset-validations": "^1.2.8",
-    "ember-cli": "~2.14.2",
+    "ember-cli": "^2.18.2",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-babel": "^6.3.0",
     "ember-cli-dependency-checker": "^1.3.0",


### PR DESCRIPTION
Was defaulting to "no example value available" because a heading value wasn't passed in.

Closes #147 