### PR TITLE
Lat lon required

### DIFF
--- a/app/controllers/data-format.js
+++ b/app/controllers/data-format.js
@@ -122,15 +122,23 @@ export default Ember.Controller.extend(sharedActions, {
       }
     },
     changeRoute: function(route){
-      if (this.model.submission.get('oaFields').number.fields.length < 1 || this.model.submission.get('oaFields').street.fields.length < 1) {
+      if (this.model.submission.get('oaFields').number.fields.length < 1 || this.model.submission.get('oaFields').street.fields.length < 1 || (this.get('store').peekAll('webServiceResponse').get('firstObject').get('conform').type === "csv" && (this.model.submission.get('oaFields').lat.fields.length < 1 || this.model.submission.get('oaFields').lon.fields.length < 1))){
         this.set('showRequiredFieldsErrorState', true);
-        if (this.model.submission.get('oaFields').number.fields.length < 1 && this.model.submission.get('oaFields').street.fields.length < 1) {
-          this.set('requiredFieldsErrorMessages', ["House number is required to proceed.", "Street is required to proceed."]);
-        } else if (this.model.submission.get('oaFields').number.fields.length < 1) {
-          this.set('requiredFieldsErrorMessages', ["House number is required to proceed."]);
-        } else if (this.model.submission.get('oaFields').street.fields.length < 1) {
-          this.set('requiredFieldsErrorMessages', ["Street is required to proceed."]);
+        this.set('requiredFieldsErrorMessages', []);
+        if (this.get('store').peekAll('webServiceResponse').get('firstObject').get('conform').type === "csv"){
+          if (this.model.submission.get('oaFields').lon.fields.length < 1){
+            this.get('requiredFieldsErrorMessages').push("Lon is required to proceed.");
+          };
+          if (this.model.submission.get('oaFields').lat.fields.length < 1){
+            this.get('requiredFieldsErrorMessages').push("Lat is required to proceed.");
+          };
         }
+        if (this.model.submission.get('oaFields').number.fields.length < 1){
+          this.get('requiredFieldsErrorMessages').push("Number is required to proceed.");
+        };
+        if (this.model.submission.get('oaFields').street.fields.length < 1){
+          this.get('requiredFieldsErrorMessages').push("Street is required to proceed.");
+        };
       } else {
         this.resetRequiredFieldsErrorState();
         this.checkFunctionRequired();

--- a/app/controllers/data-format.js
+++ b/app/controllers/data-format.js
@@ -116,7 +116,7 @@ export default Ember.Controller.extend(sharedActions, {
         Ember.set(this.model.submission.get('oaFields')[field], "function", null);
       }
       for (var i = 0; i < this.get('numberOfExamples'); i++){
-        var originalColumn = this.model.submission.get('oaFields')[field].fields[0]
+        var originalColumn = this.model.submission.get('oaFields')[field].fields[0];
         Ember.set(this.model.submission.get('exampleRows')[i], field, [this.model.webServiceResponse.get(
           'source_data').results[i][originalColumn]]);
       }
@@ -128,17 +128,17 @@ export default Ember.Controller.extend(sharedActions, {
         if (this.get('store').peekAll('webServiceResponse').get('firstObject').get('conform').type === "csv"){
           if (this.model.submission.get('oaFields').lon.fields.length < 1){
             this.get('requiredFieldsErrorMessages').push("Lon is required to proceed.");
-          };
+          }
           if (this.model.submission.get('oaFields').lat.fields.length < 1){
             this.get('requiredFieldsErrorMessages').push("Lat is required to proceed.");
-          };
+          }
         }
         if (this.model.submission.get('oaFields').number.fields.length < 1){
           this.get('requiredFieldsErrorMessages').push("Number is required to proceed.");
-        };
+        }
         if (this.model.submission.get('oaFields').street.fields.length < 1){
           this.get('requiredFieldsErrorMessages').push("Street is required to proceed.");
-        };
+        }
       } else {
         this.resetRequiredFieldsErrorState();
         this.checkFunctionRequired();

--- a/app/templates/data-format.hbs
+++ b/app/templates/data-format.hbs
@@ -10,28 +10,32 @@
         {{#each-in model.submission.oaFields as |field properties|}}
           {{#if (eq field "lon")}}
             {{#if (eq model.webServiceResponse.conform.type "csv")}}
-              <th><a onClick={{action "goToField" field}} class={{if (not-eq currentField field) "inactiveField"}}>{{field}}</a></th>
+              <th>
+                <a onClick={{action "goToField" field}} class={{if (not-eq currentField field) "inactiveField"}}>{{field}}<span class="required">*</span>
+                </a>
+              </th>
             {{/if}}
           {{/if}}
           {{#if (eq field "lat")}}
             {{#if (eq model.webServiceResponse.conform.type "csv")}}
-              <th><a onClick={{action "goToField" field}} class={{if (not-eq currentField field) "inactiveField"}}>{{field}}</a></th>
+              <th>
+                <a onClick={{action "goToField" field}} class={{if (not-eq currentField field) "inactiveField"}}>{{field}}<span class="required">*</span></a>
+              </th>
             {{/if}}
           {{/if}}
           {{#unless (eq field "lon")}}
             {{#unless (eq field "lat")}}
               <th><a onClick={{action "goToField" field}} class={{if (not-eq currentField field) "inactiveField"}}>
                 {{#if (eq field "number")}}
-                  house <br/> number
+                  house <br/> number<span class="required">*</span>
+                {{else if (eq field "street")}}
+                  street<span class="required">*</span>
                 {{else if (eq field "district")}}
                   {{field}}  {{ui-popup tagName="i" class="small info circle icon" content="District/County/Sub-Region in which the address falls"}}
                 {{else if (eq field "region")}}
                   {{field}}  {{ui-popup tagName="i" class="small info circle icon" content="State/Region/Province in which the address falls"}}
                 {{else}}
                   {{field}}
-                {{/if}}
-                {{#if (or (eq field "number") (eq field "street"))}}
-                  <span class="required"> * </span>
                 {{/if}}
               </a></th>
             {{/unless}}


### PR DESCRIPTION
Requires lat and lon fields to be matched (along with street and number) when the `conform.type === "csv"`, before the user can proceed to the next step.

Also adds a small formatting improvement for the required-field asterisk.

closes #225 