### PR TITLE
Extraction function handling improvements

### DIFF
--- a/app/components/remove-prefix-postfix.js
+++ b/app/components/remove-prefix-postfix.js
@@ -32,7 +32,7 @@ export default Ember.Component.extend({
       }
     },
     setMayContainUnits: function(){
-      if (this.model.submission.get('oaFields').street.may_contain_units === false){
+      if (this.model.submission.get('oaFields').street.may_contain_units === false || !this.model.submission.get('oaFields').street.may_contain_units){
         Ember.set(this.model.submission.get('oaFields').street, "may_contain_units", true);
       } else {
         Ember.set(this.model.submission.get('oaFields').street, "may_contain_units", false);

--- a/app/components/split-column.js
+++ b/app/components/split-column.js
@@ -24,7 +24,12 @@ export default Ember.Component.extend({
           }
         }
       }
-      Ember.set(this.model.submission.get('oaFields')[field], "function", extraction_function);
+      if (extraction_function === "removePrefixOrPostfix"){
+        // set remove_prefix as default because it is the default selection for the radio buttons
+        Ember.set(this.model.submission.get('oaFields')[field], "function", 'remove_prefix');
+      } else {
+        Ember.set(this.model.submission.get('oaFields')[field], "function", extraction_function);
+      }
     },
     removeFunction: function(field){
       if (this.model.submission.get('oaFields')[field].function === "join" && this.model.submission.get('oaFields')[field].fields.length > 1){

--- a/app/controllers/data-format.js
+++ b/app/controllers/data-format.js
@@ -63,6 +63,14 @@ export default Ember.Controller.extend(sharedActions, {
     if (this.model.submission.get('oaFields')[this.get('currentField')].function === 'join' && this.model.submission.get('oaFields')[this.get('currentField')].fields.length < 2 || this.model.submission.get('oaFields')[this.get('currentField')].function === 'split'){
       Ember.set(this.model.submission.get('oaFields')[this.get('currentField')], "function", null);
     }
+    if (this.model.submission.get('oaFields')[this.get('currentField')].function === "remove_prefix" || this.model.submission.get('oaFields')[this.get('currentField')].function === "remove_postfix"){
+      if (!this.model.submission.get('oaFields')[this.get('currentField')].prefix_or_postfix){
+        Ember.set(this.model.submission.get('oaFields')[this.get('currentField')], "function", null);
+        if (this.get('currentField') === 'street'){
+          Ember.set(this.model.submission.get('oaFields')[this.get('currentField')], "may_contain_units", false);
+        }
+      }
+    }
   },
   actions: {
     toggleShowMore: function() {

--- a/app/templates/review.hbs
+++ b/app/templates/review.hbs
@@ -131,6 +131,14 @@
                   </td>
                 </tr>
               {{/if}}
+              {{#if properties.may_contain_units}}
+                <tr>
+                  <td>May contain units</td>
+                  <td>
+                    {{properties.may_contain_units}}
+                  </td>
+                </tr>
+              {{/if}}
             </tbody>
           </table>
         {{/if}}


### PR DESCRIPTION
- if `extraction_function` is "removePrefixOrPostfix", set `remove_prefix` as default because it is the default selection for the radio buttons
- clear extraction function if second field isn't chosen
- clear may_contain_units if extraction function is cleared
- add may_contain_units to review



Closes #224