### PR TITLE
clear share-alike if license button choice is changed

### DIFF
--- a/app/controllers/more-info.js
+++ b/app/controllers/more-info.js
@@ -94,15 +94,12 @@ export default Ember.Controller.extend(sharedActions, {
   },
   actions: {
     licenseExists: function(input) {
-      // Check user interacted with attribution at all
       this.licenseSelected = true;
       this.model.set('license_exists', input)
       this.model.set('license', null);
       this.model.set('license_url', null);
       this.model.set('user_submitted_url', null);
-      // Confirm this part
-      // this.model.set('attribution', null);
-      // this.model.set('attribution_text', null);
+      this.model.set('share_alike', null);
     },
     selectLicense: function(license){
       this.model.set('license', null)


### PR DESCRIPTION
Share-alike checkbox selection wasn't cleared if user changed a "yes" answer to "Does the data have a license?" to "no" or "I don't know".